### PR TITLE
Ingester can end up owning > numTokens tokens after a restart

### DIFF
--- a/ring/ingester_lifecycle.go
+++ b/ring/ingester_lifecycle.go
@@ -103,8 +103,14 @@ func (r *IngesterRegistration) pickTokens() []uint32 {
 		takenTokens := []uint32{}
 		for _, token := range ringDesc.Tokens {
 			takenTokens = append(takenTokens, token.Token)
+			if token.Ingester == r.id {
+				tokens = append(tokens, token.Token)
+			}
 		}
-		tokens = generateTokens(r.numTokens, takenTokens)
+		if len(tokens) < r.numTokens {
+			newTokens := generateTokens(r.numTokens-len(tokens), takenTokens)
+			tokens = append(tokens, newTokens...)
+		}
 
 		ringDesc.addIngester(r.id, r.hostname, tokens)
 		return ringDesc, true, nil


### PR DESCRIPTION
When the ingester restarts, it will always claim numTokens new tokens from the ring.
It will do this even if it happens to already own tokens.
This can result in it owning many, many more times the number of tokens than it should.

This can't happen if everything shuts down gracefully, since it will delete all its tokens first. However it can and does happen easily when it respawns after a crash. We had an issue where all our ingester instances had this occur many times, until the ring grew too large to fit within consul length limits and caused the entire ingester cluster to fail.

Note that fixing https://github.com/weaveworks/frankenstein/issues/25 will likely not fix this, since it is likely that a single hostname could die and respawn within any timeout that you set for declaring an ingester dead, which leaves us back in this same situation.

The fix I would suggest is for the operation at startup, instead of adding numTokens tokens, should check how many tokens the ingester currently owns and add or remove random tokens to make the total correct. Allowing removal also nicely deals with a situation where the previous ingester process' numTokens value was higher than the new one.