### PR TITLE
Read from all ingesters, introduce 2 rings, fix deregistration

### DIFF
--- a/ring/ingester_lifecycle.go
+++ b/ring/ingester_lifecycle.go
@@ -48,7 +48,7 @@ type IngesterRegistration struct {
 }
 
 // RegisterIngester registers an ingester with Consul.
-func RegisterIngester(consulClient ConsulClient, listenPort, numTokens int) (*IngesterRegistration, error) {
+func RegisterIngester(name string, consulClient ConsulClient, listenPort, numTokens int) (*IngesterRegistration, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err
@@ -70,8 +70,9 @@ func RegisterIngester(consulClient ConsulClient, listenPort, numTokens int) (*In
 		quit:     make(chan struct{}),
 
 		consulHeartbeats: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "prism_ingester_consul_heartbeats_total",
-			Help: "The total number of heartbeats sent to consul.",
+			Name:        "prism_ingester_consul_heartbeats_total",
+			Help:        "The total number of heartbeats sent to consul.",
+			ConstLabels: map[string]string{"ring": name},
 		}),
 	}
 

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -42,6 +42,7 @@ type CoordinationStateClient interface {
 
 // Ring holds the information about the members of the consistent hash circle.
 type Ring struct {
+	name       string
 	client     CoordinationStateClient
 	quit, done chan struct{}
 
@@ -54,25 +55,32 @@ type Ring struct {
 }
 
 // New creates a new Ring
-func New(client CoordinationStateClient) *Ring {
+func New(name string, client CoordinationStateClient) *Ring {
 	r := &Ring{
+		name:   name,
 		client: client,
 		quit:   make(chan struct{}),
 		done:   make(chan struct{}),
 		ingesterOwnershipDesc: prometheus.NewDesc(
 			"prometheus_distributor_ingester_ownership_percent",
 			"The percent ownership of the ring by ingester",
-			[]string{"ingester"}, nil,
+			[]string{"ingester"}, map[string]string{
+				"ring": name,
+			},
 		),
 		ingesterTotalDesc: prometheus.NewDesc(
 			"prometheus_distributor_ingesters_total",
 			"Number of ingesters in the ring",
-			nil, nil,
+			[]string{"ring"}, map[string]string{
+				"ring": name,
+			},
 		),
 		tokensTotalDesc: prometheus.NewDesc(
 			"prometheus_distributor_tokens_total",
 			"Number of tokens in the ring",
-			nil, nil,
+			[]string{"ring"}, map[string]string{
+				"ring": name,
+			},
 		),
 	}
 	go r.loop()


### PR DESCRIPTION
Probably not related to the consul issues we're seeing, but an ingester
should unregister itself before shutting down, because it rejects new
samples during shutdown.