### PR TITLE
Check replication config at startup

### DIFF
--- a/cmd/prism/main.go
+++ b/cmd/prism/main.go
@@ -190,7 +190,10 @@ func setupDistributor(
 	chunkStore chunk.Store,
 	logSuccess bool,
 ) {
-	distributor := prism.NewDistributor(cfg)
+	distributor, err := prism.NewDistributor(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
 	prometheus.MustRegister(distributor)
 
 	prefix := "/api/prom"

--- a/distributor.go
+++ b/distributor.go
@@ -78,6 +78,12 @@ type DistributorConfig struct {
 
 // NewDistributor constructs a new Distributor
 func NewDistributor(cfg DistributorConfig) (*Distributor, error) {
+	if cfg.MinWriteSuccesses > cfg.ReplicationFactor {
+		return nil, fmt.Errorf("MinWriteSuccesses > ReplicationFactor: %d > %d", cfg.MinWriteSuccesses, cfg.ReplicationFactor)
+	}
+	if cfg.MinReadSuccesses > cfg.ReplicationFactor {
+		return nil, fmt.Errorf("MinReadSuccesses > ReplicationFactor: %d > %d", cfg.MinReadSuccesses, cfg.ReplicationFactor)
+	}
 	return &Distributor{
 		cfg:     cfg,
 		clients: map[string]*IngesterClient{},

--- a/distributor.go
+++ b/distributor.go
@@ -78,6 +78,9 @@ type DistributorConfig struct {
 
 // NewDistributor constructs a new Distributor
 func NewDistributor(cfg DistributorConfig) (*Distributor, error) {
+	if 0 > cfg.ReplicationFactor {
+		return nil, fmt.Errorf("ReplicationFactor must be greater than zero: %d", cfg.ReplicationFactor)
+	}
 	if cfg.MinWriteSuccesses > cfg.ReplicationFactor {
 		return nil, fmt.Errorf("MinWriteSuccesses > ReplicationFactor: %d > %d", cfg.MinWriteSuccesses, cfg.ReplicationFactor)
 	}

--- a/distributor.go
+++ b/distributor.go
@@ -77,7 +77,7 @@ type DistributorConfig struct {
 }
 
 // NewDistributor constructs a new Distributor
-func NewDistributor(cfg DistributorConfig) *Distributor {
+func NewDistributor(cfg DistributorConfig) (*Distributor, error) {
 	return &Distributor{
 		cfg:     cfg,
 		clients: map[string]*IngesterClient{},
@@ -118,7 +118,7 @@ func NewDistributor(cfg DistributorConfig) *Distributor {
 			Name:      "distributor_ingester_appends_total",
 			Help:      "The total number of failed queries sent to ingesters.",
 		}, []string{"ingester"}),
-	}
+	}, nil
 }
 
 func (d *Distributor) getClientFor(hostname string) (*IngesterClient, error) {


### PR DESCRIPTION
It's possible to provide a replication configuration that's guaranteed to never work. If that happens, we should fail fast, triggering a crashloop backoff and thus a deployment fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/prism/56)
<!-- Reviewable:end -->
