### PR TITLE
Fix chunk max age handling

### DIFF
--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -452,7 +452,7 @@ func (i *Ingester) flushSeries(ctx context.Context, u *userState, fp model.Finge
 	u.fpLocker.Lock(fp)
 
 	// Decide what chunks to flush
-	if immediate || time.Now().Sub(series.firstTime().Time()) > i.cfg.MaxChunkAge {
+	if immediate || time.Now().Sub(series.head().FirstTime().Time()) > i.cfg.MaxChunkAge {
 		series.headChunkClosed = true
 		series.headChunkUsedByIterator = false
 		series.head().MaybePopulateLastTime()


### PR DESCRIPTION
Only close the head chunk if its own first sample is too old, not if the
first sample of the entire series before it is too old.