### PR TITLE
Fix removal of persisted chunks from memory

### DIFF
--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -474,7 +474,7 @@ func (i *Ingester) flushSeries(ctx context.Context, u *userState, fp model.Finge
 
 	// now remove the chunks
 	u.fpLocker.Lock(fp)
-	series.chunkDescs = series.chunkDescs[len(chunks)-1:]
+	series.chunkDescs = series.chunkDescs[len(chunks):]
 	i.memoryChunks.Sub(float64(len(chunks)))
 	if len(series.chunkDescs) == 0 {
 		u.fpToSeries.del(fp)


### PR DESCRIPTION
There's an OBOB in there. According to my understanding, it would
currently keep one already persisted chunk in memory and then persist it
again every minute, until there's another full chunk (then the old one
would finally get dropped).

Indeed, looking at how many series the ingester has in memory:

  prism_ingester_memory_series

...and comparing that to how many chunks are being written out per
minute:

  rate(prism_ingester_chunk_utilization_count[1h]) * 60

The number of chunks being persisted every minute is coming quite close
to the number of series in memory. We should watch for a sharp drop of
the latter rate after merging this.