### PR TITLE
More visibility on ingesters

### DIFF
--- a/distributor.go
+++ b/distributor.go
@@ -114,7 +114,7 @@ func NewDistributor(cfg DistributorConfig) (*Distributor, error) {
 		}, []string{"ingester"}),
 		ingesterAppendFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "prism",
-			Name:      "distributor_ingester_appends_total",
+			Name:      "distributor_ingester_append_failures_total",
 			Help:      "The total number of failed batch appends sent to ingesters.",
 		}, []string{"ingester"}),
 		ingesterQueries: prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -124,7 +124,7 @@ func NewDistributor(cfg DistributorConfig) (*Distributor, error) {
 		}, []string{"ingester"}),
 		ingesterQueryFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "prism",
-			Name:      "distributor_ingester_appends_total",
+			Name:      "distributor_ingester_query_failures_total",
 			Help:      "The total number of failed queries sent to ingesters.",
 		}, []string{"ingester"}),
 	}, nil

--- a/distributor.go
+++ b/distributor.go
@@ -263,6 +263,10 @@ func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers .
 			return err
 		}
 
+		if len(ingesters) < d.cfg.MinReadSuccesses {
+			return fmt.Errorf("Could only find %d ingesters for query. Need at least %d", len(ingesters), d.cfg.MinReadSuccesses)
+		}
+
 		// Fetch samples from multiple ingesters and group them by fingerprint (unsorted
 		// and with overlap).
 		successes := 0

--- a/distributor.go
+++ b/distributor.go
@@ -129,7 +129,7 @@ func NewDistributor(cfg DistributorConfig) (*Distributor, error) {
 			Help:      "The total number of failed queries sent to ingesters.",
 		}, []string{"ingester"}),
 		ingestersAlive: prometheus.NewDesc(
-			"prism_distributor_ingesters_alive_total",
+			"prism_distributor_ingesters_alive",
 			"Number of ingesters in the ring that have heartbeats within timeout.",
 			nil, nil,
 		),

--- a/distributor.go
+++ b/distributor.go
@@ -264,7 +264,7 @@ func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers .
 		}
 
 		if len(ingesters) < d.cfg.MinReadSuccesses {
-			return fmt.Errorf("Could only find %d ingesters for query. Need at least %d", len(ingesters), d.cfg.MinReadSuccesses)
+			return fmt.Errorf("could only find %d ingesters for query. Need at least %d", len(ingesters), d.cfg.MinReadSuccesses)
 		}
 
 		// Fetch samples from multiple ingesters and group them by fingerprint (unsorted

--- a/distributor.go
+++ b/distributor.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	numClientsDesc = prometheus.NewDesc(
-		"prometheus_distributor_ingester_clients",
+		"prism_distributor_ingester_clients",
 		"The current number of ingester clients.",
 		nil, nil,
 	)

--- a/distributor.go
+++ b/distributor.go
@@ -363,6 +363,10 @@ func (d *Distributor) Describe(ch chan<- *prometheus.Desc) {
 	d.sendDuration.Describe(ch)
 	d.cfg.Ring.Describe(ch)
 	ch <- numClientsDesc
+	d.ingesterAppends.Describe(ch)
+	d.ingesterAppendFailures.Describe(ch)
+	d.ingesterQueries.Describe(ch)
+	d.ingesterQueryFailures.Describe(ch)
 }
 
 // Collect implements prometheus.Collector.
@@ -371,6 +375,10 @@ func (d *Distributor) Collect(ch chan<- prometheus.Metric) {
 	ch <- d.receivedSamples
 	d.sendDuration.Collect(ch)
 	d.cfg.Ring.Collect(ch)
+	d.ingesterAppends.Collect(ch)
+	d.ingesterAppendFailures.Collect(ch)
+	d.ingesterQueries.Collect(ch)
+	d.ingesterQueryFailures.Collect(ch)
 
 	d.clientsMtx.RLock()
 	defer d.clientsMtx.RUnlock()

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -50,8 +50,8 @@ type Ring struct {
 	ringDesc Desc
 
 	ingesterOwnershipDesc *prometheus.Desc
-	ingesterTotalDesc     *prometheus.Desc
-	tokensTotalDesc       *prometheus.Desc
+	numIngestersDesc      *prometheus.Desc
+	numTokensDesc         *prometheus.Desc
 }
 
 // New creates a new Ring
@@ -65,13 +65,13 @@ func New(client CoordinationStateClient) *Ring {
 			"The percent ownership of the ring by ingester",
 			[]string{"ingester"}, nil,
 		),
-		ingesterTotalDesc: prometheus.NewDesc(
-			"prism_distributor_ingesters_total",
+		numIngestersDesc: prometheus.NewDesc(
+			"prism_distributor_ingesters",
 			"Number of ingesters in the ring",
 			nil, nil,
 		),
-		tokensTotalDesc: prometheus.NewDesc(
-			"prism_distributor_tokens_total",
+		numTokensDesc: prometheus.NewDesc(
+			"prism_distributor_tokens",
 			"Number of tokens in the ring",
 			nil, nil,
 		),
@@ -166,8 +166,8 @@ func (r *Ring) search(key uint32) int {
 // Describe implements prometheus.Collector.
 func (r *Ring) Describe(ch chan<- *prometheus.Desc) {
 	ch <- r.ingesterOwnershipDesc
-	ch <- r.ingesterTotalDesc
-	ch <- r.tokensTotalDesc
+	ch <- r.numIngestersDesc
+	ch <- r.numTokensDesc
 }
 
 // Collect implements prometheus.Collector.
@@ -196,12 +196,12 @@ func (r *Ring) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	ch <- prometheus.MustNewConstMetric(
-		r.ingesterTotalDesc,
+		r.numIngestersDesc,
 		prometheus.GaugeValue,
 		float64(len(r.ringDesc.Ingesters)),
 	)
 	ch <- prometheus.MustNewConstMetric(
-		r.tokensTotalDesc,
+		r.numTokensDesc,
 		prometheus.GaugeValue,
 		float64(len(r.ringDesc.Tokens)),
 	)

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -61,17 +61,17 @@ func New(client CoordinationStateClient) *Ring {
 		quit:   make(chan struct{}),
 		done:   make(chan struct{}),
 		ingesterOwnershipDesc: prometheus.NewDesc(
-			"prometheus_distributor_ingester_ownership_percent",
+			"prism_distributor_ingester_ownership_percent",
 			"The percent ownership of the ring by ingester",
 			[]string{"ingester"}, nil,
 		),
 		ingesterTotalDesc: prometheus.NewDesc(
-			"prometheus_distributor_ingesters_total",
+			"prism_distributor_ingesters_total",
 			"Number of ingesters in the ring",
 			nil, nil,
 		),
 		tokensTotalDesc: prometheus.NewDesc(
-			"prometheus_distributor_tokens_total",
+			"prism_distributor_tokens_total",
 			"Number of tokens in the ring",
 			nil, nil,
 		),


### PR DESCRIPTION
I guess this fixes #60. Gives us a measure of non-dead ingesters. 

Also, I noticed that the reason we'd be getting `nil` errors on query failures is that we haven't got enough ingesters, so I added an early failure path with a better error message.

I thought about adding a crappy status page at `/ringz` or something, but I would have had to pierce through a layer or two of abstraction and decided that it wasn't worth the effort. Happy to revisit if people think otherwise.

Assumes #65 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/prism/68)
<!-- Reviewable:end -->
